### PR TITLE
WEB3 978 Fix overflow mobile menu and drawer scroll

### DIFF
--- a/components/design-system/MDrawer.vue
+++ b/components/design-system/MDrawer.vue
@@ -10,7 +10,7 @@
       >
         <div
           ref="drawer-backdrop"
-          class="fixed bottom-0 z-50 w-full lg:w-1/2 lg:left-[50%] h-screen p-4 overflow-y-auto bg-white shadow-[0px_0px_0px_20px_rgba(0,0,0,0.3)] transition-transform"
+          class="fixed bottom-0 z-50 w-full lg:w-1/2 lg:left-[50%] h-dvh p-4 overflow-y-scroll bg-white shadow-[0px_0px_0px_20px_rgba(0,0,0,0.3)] transition-transform"
           tabindex="-1"
           aria-labelledby="drawer-label"
         >

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,7 @@
       :sidebar-open="isSidebarOpen"
       @toggle-sidebar="isSidebarOpen = !isSidebarOpen"
     />
-    <div class="flex flex-col app-content">
+    <div class="flex flex-col h-dvh">
       <div class="flex grow xl:gap-6">
         <aside :class="{ '!block': isSidebarOpen }">
           <LayoutSidebar />
@@ -40,8 +40,5 @@ watch(
 <style scoped>
 aside {
   @apply fixed lg:static w-full h-screen lg:h-auto lg:min-w-[280px] lg:w-auto overflow-hidden  p-6 pt-0 lg:pl-16 hidden lg:block bg-grey-900;
-}
-.app-content {
-  height: calc(100vh);
 }
 </style>


### PR DESCRIPTION
Fix proposal details `drawer` scroll and position in screen. Also fixed mobile menu that overflows without the possiblity of scrolling.