### PR TITLE
WEB3 996 remove duplicates by account/role in actors

### DIFF
--- a/pages/actors.vue
+++ b/pages/actors.vue
@@ -33,6 +33,7 @@
 </template>
 
 <script setup lang="ts">
+import uniqBy from "lodash/uniqBy";
 import { storeToRefs } from "pinia";
 
 const apiStore = useApiClientStore();
@@ -72,13 +73,10 @@ const listsOptions = computed(() => [
 const selectedList = ref("all");
 
 const filteredLists = computed(() => {
-  const listsWithoutDuplicates = lists.value.filter((e, i) => {
-    return (
-      lists.value.findIndex((x) => {
-        return x.account == e.account && x.list == e.list;
-      }) == i
-    );
-  });
+  const listsWithoutDuplicates = uniqBy(
+    lists.value,
+    (item) => item.account + item.list,
+  );
 
   if (selectedList.value === "all") return listsWithoutDuplicates;
   return listsWithoutDuplicates.filter(

--- a/pages/actors.vue
+++ b/pages/actors.vue
@@ -72,8 +72,18 @@ const listsOptions = computed(() => [
 const selectedList = ref("all");
 
 const filteredLists = computed(() => {
-  if (selectedList.value === "all") return lists.value;
-  return lists.value.filter((obj) => obj.list === selectedList.value);
+  const listsWithoutDuplicates = lists.value.filter((e, i) => {
+    return (
+      lists.value.findIndex((x) => {
+        return x.account == e.account && x.list == e.list;
+      }) == i
+    );
+  });
+
+  if (selectedList.value === "all") return listsWithoutDuplicates;
+  return listsWithoutDuplicates.filter(
+    (obj) => obj.list === selectedList.value,
+  );
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
In `Actors` page is removed all duplicates with the same account and role.

Before:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/0bbe1d94-98bf-464f-a990-bc885614ad85)
After:
![image](https://github.com/MZero-Labs/ttg-frontend/assets/146194347/28bbf16c-855d-40a6-9324-d5d4afa5e067)
