### PR TITLE
WEB3 986 add deployment hash and links to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # M^0 Governance dApp
 
-[Current IPFS Deployment](https://bafybeibbuu7pjl6eq3ispwvgk76en6f74uusibs7vva3plzp4wkghlt7ry.ipfs.cf-ipfs.com/proposals)
+#### Current decentralized deployments:
+IPFS: [bafybeig4d3u2yuo2aflp7pobps3rh5vlvlofowa6zrpwbpunwzxjtjbeoq](https://bafybeig4d3u2yuo2aflp7pobps3rh5vlvlofowa6zrpwbpunwzxjtjbeoq.ipfs.cf-ipfs.com/proposals)
+
+Arweave: vET9BYjLCjv8cjQDxfwbAzauQdaw92lwy4ZcCskeJN4
 
 <img width="1089" alt="Screenshot 2024-05-14 at 2 04 43 PM" src="https://github.com/MZero-Labs/ttg-frontend/assets/1220854/f63ccd58-99b4-48fd-871f-f6016812f380">
 


### PR DESCRIPTION
Added new section to README with current deployments hashes and link in IPFS.

`Latest:`
#### Current decentralized deployments:
IPFS: [bafybeig4d3u2yuo2aflp7pobps3rh5vlvlofowa6zrpwbpunwzxjtjbeoq](https://bafybeig4d3u2yuo2aflp7pobps3rh5vlvlofowa6zrpwbpunwzxjtjbeoq.ipfs.cf-ipfs.com/proposals)
Arweave: vET9BYjLCjv8cjQDxfwbAzauQdaw92lwy4ZcCskeJN4